### PR TITLE
avoid vizimajac to get into void

### DIFF
--- a/adnd.pl
+++ b/adnd.pl
@@ -290,7 +290,7 @@ sub sig_nick {
   if ( exists $scene->{characters}->{character}->{$nick} ) {
       print "nickvaltas $nick => $newnick";
       $scene->{characters}->{character}->{$newnick} = $scene->{characters}->{character}->{$nick};
-      undef $scene->{characters}->{character}->{$nick};
+      delete $scene->{characters}->{character}->{$nick};
   }
 }
 


### PR DESCRIPTION
undef assigns az undef value to the nick key, resulting the user to get into nowhere and screwing up game logic